### PR TITLE
release: prepare release v1.2.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,7 +270,7 @@ jobs:
         id: build
         run: |
           helm package install/chart --dependency-update --version ${{ github.ref_name }}
-          echo "package=dir-runtime-${{ github.ref_name }}.tgz" >> "$GITHUB_OUTPUT"
+          echo "package=runtime-${{ github.ref_name }}.tgz" >> "$GITHUB_OUTPUT"
 
       - name: Helm push to GHCR OCI registry
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v1.0.0] - 2026-04-27
+## [v1.2.1] - 2026-04-27
 
 Initial release of Directory Runtime as a standalone repository, migrated from
-[agntcy/dir](https://github.com/agntcy/dir).
+[agntcy/dir](https://github.com/agntcy/dir). Version starts at v1.2.1 to avoid
+conflicts with existing container images published from the monorepo.
 
 ### Added
 - **Discovery**: Event-based Docker container discovery with real-time monitoring
@@ -28,4 +29,4 @@ Initial release of Directory Runtime as a standalone repository, migrated from
 - **Tooling**: Pre-commit hooks with golangci-lint integration
 - **Tooling**: Code coverage reporting with Codecov
 
-[Full Changelog](https://github.com/agntcy/dir-runtime/releases/tag/v1.0.0)
+[Full Changelog](https://github.com/agntcy/dir-runtime/releases/tag/v1.2.1)

--- a/discovery/go.mod
+++ b/discovery/go.mod
@@ -13,9 +13,9 @@ replace (
 replace github.com/ThalesIgnite/crypto11 => github.com/ThalesGroup/crypto11 v1.6.0
 
 require (
-	github.com/agntcy/dir-runtime/api v1.0.0
-	github.com/agntcy/dir-runtime/store v1.0.0
-	github.com/agntcy/dir-runtime/utils v1.0.0
+	github.com/agntcy/dir-runtime/api v1.2.1
+	github.com/agntcy/dir-runtime/store v1.2.1
+	github.com/agntcy/dir-runtime/utils v1.2.1
 	github.com/agntcy/dir/client v1.2.0
 	github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c
 	github.com/moby/moby/api v1.54.2

--- a/server/go.mod
+++ b/server/go.mod
@@ -10,9 +10,9 @@ replace (
 )
 
 require (
-	github.com/agntcy/dir-runtime/api v1.0.0
-	github.com/agntcy/dir-runtime/store v1.0.0
-	github.com/agntcy/dir-runtime/utils v1.0.0
+	github.com/agntcy/dir-runtime/api v1.2.1
+	github.com/agntcy/dir-runtime/store v1.2.1
+	github.com/agntcy/dir-runtime/utils v1.2.1
 	github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1

--- a/store/go.mod
+++ b/store/go.mod
@@ -9,8 +9,8 @@ replace (
 )
 
 require (
-	github.com/agntcy/dir-runtime/api v1.0.0
-	github.com/agntcy/dir-runtime/utils v1.0.0
+	github.com/agntcy/dir-runtime/api v1.2.1
+	github.com/agntcy/dir-runtime/utils v1.2.1
 	github.com/glebarez/sqlite v1.11.0
 	go.etcd.io/etcd/client/v3 v3.6.10
 	google.golang.org/protobuf v1.36.11

--- a/versions.yaml
+++ b/versions.yaml
@@ -3,7 +3,7 @@
 
 module-sets:
   dir-runtime:
-    version: v1.0.0
+    version: v1.2.1
     modules:
       - github.com/agntcy/dir-runtime/api
       - github.com/agntcy/dir-runtime/discovery


### PR DESCRIPTION
This PR fixes the Helm chart release failure and bumps the initial version to v1.2.1 to avoid conflicts with existing container images published from the `agntcy/dir` monorepo.

* Fix Helm package filename in CI to match chart name runtime instead of dir-runtime
* Bump version from v1.0.0 to v1.2.1 in versions.yaml, go.mod files, and CHANGELOG.md